### PR TITLE
Move CI build target to Docker Hub

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -88,24 +88,24 @@ jobs:
           path: build/${{ matrix.targetPlatform }}
 
       # Phase 2 - Docker Containerization
-      - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/${{ matrix.dockerImage }}
+          images: cmusei/${{ matrix.dockerImage }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: ./build/${{ matrix.targetPlatform }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: Dockerfile.${{ matrix.targetPlatform }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -89,7 +89,7 @@ jobs:
 
       # Phase 2 - Docker Containerization
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
+        #if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -105,7 +105,8 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: ./build/${{ matrix.targetPlatform }}
-          push: ${{ github.event_name != 'pull_request' }}
+          #push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: Dockerfile.${{ matrix.targetPlatform }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,9 +8,6 @@ on:
       - dev
       - test
   workflow_dispatch:
-env:
-  REGISTRY: ghcr.io
-  ORGANIZATION: cmu-sei
 
 jobs:
   # Phase 1 - Unity Build
@@ -31,10 +28,8 @@ jobs:
         include:
           - targetPlatform: StandaloneLinux64
             dockerImage: cubespace-server
-            customImage: "unityci/editor:2021.3.4f1-linux-il2cpp-1"
           - targetPlatform: WebGL
             dockerImage: cubespace-client
-            customImage: ""
     steps:
       # Checkout
       - name: Checkout project repo
@@ -70,7 +65,6 @@ jobs:
           projectPath: ${{ matrix.projectPath }}
           unityVersion: ${{ matrix.unityVersion }}
           targetPlatform: ${{ matrix.targetPlatform }}
-          customImage: ${{ matrix.customImage }}
 
       # Build
       - name: Build ${{ matrix.targetPlatform }}
@@ -85,7 +79,6 @@ jobs:
           projectPath: ${{ matrix.projectPath }}
           unityVersion: ${{ matrix.unityVersion }}
           targetPlatform: ${{ matrix.targetPlatform }}
-          customImage: ${{ matrix.customImage }}
 
       # Upload
       - name: Upload game artifact

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -46,6 +46,7 @@ jobs:
       # Restore Cache
       - name: Restore cached Library folder if it exists
         uses: actions/cache@v3.0.8
+        id: cache-exists
         with:
           path: Library
           key:
@@ -55,7 +56,22 @@ jobs:
             Library-${{ matrix.projectPath }}-
             Library-
 
-      # Test (no tests)
+      # Generate Library when cache does not exist
+      - name: Generate Library folder
+        uses: game-ci/unity-builder@v2.1.1
+        if: ${{ !steps.cache-exists.outputs.cache-hit && (matrix.targetPlatform == 'StandaloneLinux64') }}
+        env:
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+        with:
+          buildMethod: UnityBuilderAction.BuildScript.BuildGame
+          # If we have custom parameters, add them here with: customParameters: '-myParameter myValue -myBoolean -ThirdParameter andItsValue'
+          projectPath: ${{ matrix.projectPath }}
+          unityVersion: ${{ matrix.unityVersion }}
+          targetPlatform: ${{ matrix.targetPlatform }}
+          customImage: ${{ matrix.customImage }}
+
       # Build
       - name: Build ${{ matrix.targetPlatform }}
         uses: game-ci/unity-builder@v2.1.1

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,14 +33,14 @@ jobs:
     steps:
       # Checkout
       - name: Checkout project repo
-        uses: actions/checkout@v2.4.2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           lfs: false
 
       # Restore Cache
       - name: Restore cached Library folder if it exists
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3
         id: cache-exists
         with:
           path: Library
@@ -90,19 +90,19 @@ jobs:
       # Phase 2 - Docker Containerization
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4
         with:
           images: cmusei/${{ matrix.dockerImage }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v4
         with:
           context: ./build/${{ matrix.targetPlatform }}
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -89,7 +89,7 @@ jobs:
 
       # Phase 2 - Docker Containerization
       - name: Login to DockerHub
-        #if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -105,8 +105,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: ./build/${{ matrix.targetPlatform }}
-          #push: ${{ github.event_name != 'pull_request' }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: Dockerfile.${{ matrix.targetPlatform }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,8 +31,10 @@ jobs:
         include:
           - targetPlatform: StandaloneLinux64
             dockerImage: cubespace-server
+            customImage: "unityci/editor:2021.3.4f1-linux-il2cpp-1"
           - targetPlatform: WebGL
             dockerImage: cubespace-client
+            customImage: ""
     steps:
       # Checkout
       - name: Checkout project repo
@@ -40,106 +42,10 @@ jobs:
         with:
           fetch-depth: 0
           lfs: false
-  
+
       # Restore Cache
       - name: Restore cached Library folder if it exists
         uses: actions/cache@v3.0.8
-        id: cache-exists
-        with:
-          path: Library
-          key:
-            Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}-${{ hashFiles(matrix.projectPath) }}
-          restore-keys: |
-            Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}-
-            Library-${{ matrix.projectPath }}-
-            Library-
-      
-      # Test (no tests)
-      # Build
-      - name: Build ${{ matrix.targetPlatform }}
-        uses: game-ci/unity-builder@v2.1.1
-        env:
-          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
-        with:
-          buildMethod: UnityBuilderAction.BuildScript.BuildGame
-          # If we have custom parameters, add them here with: customParameters: '-myParameter myValue -myBoolean -ThirdParameter andItsValue'
-          projectPath: ${{ matrix.projectPath }}
-          unityVersion: ${{ matrix.unityVersion }}
-          targetPlatform: ${{ matrix.targetPlatform }}
-        
-      # Upload
-      - name: Upload game artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.targetPlatform }} Build
-          path: build/${{ matrix.targetPlatform }}
-      
-      # Phase 2 - Docker Containerization
-      - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/${{ matrix.dockerImage }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: ./build/${{ matrix.targetPlatform }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          file: Dockerfile.${{ matrix.targetPlatform }}
-
-      - name: Cleanup Docker System
-        run: docker system prune -a -f
-    
-    # Output cache exists variable
-    outputs:
-      cache-exists: ${{ steps.cache-exists.outputs.cache-hit }}
-      
-  # Rebuild and upload if the cache did not exist to avoid server error
-  rebuild:
-    name: Rebuild game
-    runs-on: self-hosted
-    needs: build
-    if: ${{ needs.build.outputs.cache-exists != 'true' }}
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        unityVersion:
-          - 2021.3.4f1
-        targetPlatform:
-          - StandaloneLinux64 # Target build for Linux standalone
-          - WebGL # Target build for WebGL
-        include:
-          - targetPlatform: StandaloneLinux64
-            dockerImage: cubespace-server
-          - targetPlatform: WebGL
-            dockerImage: cubespace-client
-    steps:
-      # Checkout
-      - name: Checkout project repo
-        uses: actions/checkout@v2.4.2
-        with:
-          fetch-depth: 0
-          lfs: false
-  
-      # Restore Cache
-      - name: Restore cached Library folder if it exists
-        uses: actions/cache@v3.0.8
-        id: cache-exists
         with:
           path: Library
           key:
@@ -163,6 +69,7 @@ jobs:
           projectPath: ${{ matrix.projectPath }}
           unityVersion: ${{ matrix.unityVersion }}
           targetPlatform: ${{ matrix.targetPlatform }}
+          customImage: ${{ matrix.customImage }}
 
       # Upload
       - name: Upload game artifact


### PR DESCRIPTION
Moves CI build target to Docker Hub.

Simplifies CI rebuild process for StandaloneLinux64 build when `/Library` folder is not cached.

Closes #17 